### PR TITLE
Incorporate serializer_id column added in 1.3.1 into main SQL DDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ CREATE TABLE {your_journal_table_name} (
     manifest VARCHAR(500) NOT NULL,
     payload BYTEA NOT NULL,
     tags VARCHAR(100) NULL,
+    serializer_id INTEGER NULL,
     CONSTRAINT {your_journal_table_name}_uq UNIQUE (persistence_id, sequence_nr)
 );
 
@@ -100,6 +101,7 @@ CREATE TABLE {your_snapshot_table_name} (
     created_at BIGINT NOT NULL,
     manifest VARCHAR(500) NOT NULL,
     snapshot BYTEA NOT NULL,
+    serializer_id INTEGER NULL,
     CONSTRAINT {your_snapshot_table_name}_pk PRIMARY KEY (persistence_id, sequence_nr)
 );
 


### PR DESCRIPTION
The content for the `CREATE TABLE` statements hasn't been updated for 1.3.1, and it isn't clear that one must apply the 1.1.0 to 1.3.1 migration after executing the main script.  This commit brings the main SQL script up to 1.3.1 so that when executed, no additional migration is necessary.